### PR TITLE
Update to support Less 3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,8 @@ class LessPluginInlineSvg {
 
         less.functions.functionRegistry.addMultiple({
             'inline-svg'(fileArg, iconIdArg, svgArgs) {
-                const { currentFileInfo, value } = fileArg;
-                const { currentDirectory } = currentFileInfo;
+                const { value } = fileArg;
+                const { currentDirectory } = this.currentFileInfo;
 
                 const filePath = join(currentDirectory, value);
                 let svgCode = readFileSync(filePath);

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "htmlparser2": "^3.9.2"
   },
   "devDependencies": {
-    "less": "^2.5.1"
+    "less": "^3.9.0"
   },
   "peerDependencies": {
-    "less": "^2.5.1"
+    "less": "^2.7.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
I ran in to this error while upgrading from Less 2.x -> 3.x using this plugin.

```
error evaluating function `inline-svg`: The "path" argument must be of type string. Received type undefined
```

Looks like this is happening because `currentDirectory` ends up being `undefined`. I'm not particularly familiar with how Less functions are implemented, so apologies if there's a better or more idiomatic fix. I sanity checked this against `less@~2.7.0` and `less@~3.9.0` and they both seem to work fine after this change. 

Fixes #3 